### PR TITLE
Update tmux prefix & color

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -1,4 +1,4 @@
-set -g prefix C-x
+set -g prefix C-,
 set -g base-index 1
 setw -g pane-base-index 1
 
@@ -12,3 +12,5 @@ bind v select-layout even-vertical
 unbind C-b
 unbind -T copy-mode Enter
 bind -T copy-mode Enter send-keys -X copy-pipe-and-cancel "pbcopy"
+
+set -g default-terminal "xterm-256color"


### PR DESCRIPTION
- prefix C-x だと emacs と重複する
    - 何にも使われていない `C-,` であれば少ないキーでprefix にできる
    - 両手使うのはネック
- tmux 上で emacs 使う際にiTerm2で設定しているカラーが反映されていないためコンフィグに追加