### PR TITLE
Alias julia command directly

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -92,6 +92,7 @@ alias sudo="sudo " # For using local alias
 alias t="tig"
 alias timestamp='date +%s.%N'
 alias unmount='diskutil unmount'
+alias julia="$HOME/julia/julia"
 
 # source ~/.git-completion.
 
@@ -150,7 +151,6 @@ function loadpath() {
 loadpath $HOME/.bin
 loadpath $HOME/.pyenv/shims
 loadpath $HOME/.rbenv/shims
-loadpath $HOME/julia/usr/bin
 loadpath $HOME/flutter/bin
 
 if [ -d "$HOME/julia/libmxnet" ] ; then


### PR DESCRIPTION
- `loadpath` で julia コマンドへのパスを通すと `julia/bin` に含まれる他のコマンドにもパスが通る(curlなど)
    - この `curl` コマンドでパッケージのインストールに失敗することがある
    - Ref: https://scrapbox.io/phigasui/curl:_(51)_Cert_verify_failed:_BADCERT_NOT_TRUSTED